### PR TITLE
Add conversational AI platform skeleton

### DIFF
--- a/conversational-ai-platform/PostmanCollection.json
+++ b/conversational-ai-platform/PostmanCollection.json
@@ -1,0 +1,20 @@
+{
+  "info": {
+    "name": "Conversational API",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Send Intent",
+      "request": {
+        "method": "POST",
+        "header": [{"key":"Content-Type","value":"application/json"}],
+        "url": "http://localhost:3001/nlu/intent",
+        "body": {
+          "mode": "raw",
+          "raw": "{\"utterance\": \"hello\"}"
+        }
+      }
+    }
+  ]
+}

--- a/conversational-ai-platform/README.md
+++ b/conversational-ai-platform/README.md
@@ -1,0 +1,20 @@
+# Conversational AI Platform
+
+This repository contains a simple modular platform that connects a voice channel (e.g., Genesys) to a Dialogflow CX agent with analytics and a dashboard.
+
+## Structure
+- **backend** – Express + TypeScript API exposing NLU and analytics endpoints.
+- **frontend** – React dashboard with Recharts.
+- **dialogflow-agent-sample** – Importable Dialogflow CX agent JSON.
+- **architect-flow-sample** – Example Genesys Architect flow YAML.
+
+## Quick start
+
+```bash
+npm install --prefix backend
+npm test --prefix backend
+npm install --prefix frontend
+npm run build --prefix frontend
+```
+
+Use `docker-compose up --build` to run the stack with PostgreSQL.

--- a/conversational-ai-platform/architect-flow-sample/sample-flow.yaml
+++ b/conversational-ai-platform/architect-flow-sample/sample-flow.yaml
@@ -1,0 +1,11 @@
+---
+version: 1
+start:
+  - call_incoming
+call_incoming:
+  description: "Sample entry point"
+  actions:
+    - data_action: send_to_backend
+send_to_backend:
+  request:
+    url: "http://backend:3001/nlu/intent"

--- a/conversational-ai-platform/backend/Dockerfile
+++ b/conversational-ai-platform/backend/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json tsconfig.json jest.config.js ./
+RUN npm install --production=false && npm cache clean --force
+COPY src ./src
+COPY test ./test
+RUN npm run build
+CMD ["npm", "start"]

--- a/conversational-ai-platform/backend/jest.config.js
+++ b/conversational-ai-platform/backend/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/test/**/*.test.ts']
+};

--- a/conversational-ai-platform/backend/package.json
+++ b/conversational-ai-platform/backend/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "main": "dist/app.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/app.js",
+    "dev": "ts-node src/app.ts",
+    "test": "jest --coverage"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/jest": "^29.5.3",
+    "@types/node": "^20.12.5",
+    "jest": "^29.7.0",
+    "supertest": "^6.3.4",
+    "ts-jest": "^29.1.1",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.3"
+  }
+}

--- a/conversational-ai-platform/backend/src/app.ts
+++ b/conversational-ai-platform/backend/src/app.ts
@@ -1,0 +1,18 @@
+import express from 'express';
+import nluRouter from './routes/nlu';
+import analyticsRouter from './routes/analytics';
+
+const app = express();
+app.use(express.json());
+
+app.use('/nlu', nluRouter);
+app.use('/analytics', analyticsRouter);
+
+export default app;
+
+if (require.main === module) {
+  const port = process.env.PORT || 3001;
+  app.listen(port, () => {
+    console.log(`Backend listening on port ${port}`);
+  });
+}

--- a/conversational-ai-platform/backend/src/routes/analytics.ts
+++ b/conversational-ai-platform/backend/src/routes/analytics.ts
@@ -1,0 +1,28 @@
+import { Router } from 'express';
+
+interface LogEntry {
+  session_id: string;
+  timestamp: number;
+  intent: string;
+  confidence: number;
+}
+
+const logs: LogEntry[] = [];
+
+const router = Router();
+
+router.post('/log', (req, res) => {
+  const entry = req.body as LogEntry;
+  logs.push(entry);
+  res.status(201).json({ status: 'logged' });
+});
+
+router.get('/dashboard', (_req, res) => {
+  const intents: Record<string, number> = {};
+  logs.forEach(l => {
+    intents[l.intent] = (intents[l.intent] || 0) + 1;
+  });
+  res.json({ count: logs.length, intents });
+});
+
+export default router;

--- a/conversational-ai-platform/backend/src/routes/nlu.ts
+++ b/conversational-ai-platform/backend/src/routes/nlu.ts
@@ -1,0 +1,17 @@
+import { Router } from 'express';
+
+const router = Router();
+
+router.post('/intent', (req, res) => {
+  const { utterance } = req.body;
+  // Placeholder NLU integration
+  const intent = utterance?.includes('pension') ? 'pension_eligibility' : 'unknown';
+  res.json({ intent, replyText: `You said: ${utterance}` });
+});
+
+router.post('/event', (req, res) => {
+  const { event } = req.body;
+  res.json({ eventHandled: event });
+});
+
+export default router;

--- a/conversational-ai-platform/backend/test/app.test.ts
+++ b/conversational-ai-platform/backend/test/app.test.ts
@@ -1,0 +1,15 @@
+import request from 'supertest';
+import app from '../src/app';
+
+describe('API', () => {
+  it('intent endpoint returns reply', async () => {
+    const res = await request(app).post('/nlu/intent').send({ utterance: 'tell me about pension' });
+    expect(res.body.intent).toBe('pension_eligibility');
+  });
+
+  it('analytics log and dashboard', async () => {
+    await request(app).post('/analytics/log').send({ session_id: '1', timestamp: Date.now(), intent: 'test', confidence: 0.9 });
+    const res = await request(app).get('/analytics/dashboard');
+    expect(res.body.count).toBeGreaterThan(0);
+  });
+});

--- a/conversational-ai-platform/backend/tsconfig.json
+++ b/conversational-ai-platform/backend/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"]
+}

--- a/conversational-ai-platform/dialogflow-agent-sample/SamplePublicBenefits.agent.json
+++ b/conversational-ai-platform/dialogflow-agent-sample/SamplePublicBenefits.agent.json
@@ -1,0 +1,12 @@
+{
+  "displayName": "SamplePublicBenefits",
+  "defaultLanguageCode": "en",
+  "intents": [
+    { "displayName": "unemployment_info" },
+    { "displayName": "pension_eligibility" },
+    { "displayName": "disability_support" },
+    { "displayName": "child_support_query" },
+    { "displayName": "wrong_number" },
+    { "displayName": "change_topic" }
+  ]
+}

--- a/conversational-ai-platform/docker-compose.yml
+++ b/conversational-ai-platform/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3'
+services:
+  backend:
+    build: ./backend
+    ports:
+      - "3001:3001"
+  frontend:
+    build: ./frontend
+    ports:
+      - "3000:3000"
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: convo
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: pass
+    ports:
+      - "5432:5432"

--- a/conversational-ai-platform/frontend/Dockerfile
+++ b/conversational-ai-platform/frontend/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json tsconfig.json index.html ./
+RUN npm install && npm cache clean --force
+COPY src ./src
+RUN npm run build
+CMD ["npx", "serve", "dist"]

--- a/conversational-ai-platform/frontend/index.html
+++ b/conversational-ai-platform/frontend/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Dashboard</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script src="./dist/main.js"></script>
+  </body>
+</html>

--- a/conversational-ai-platform/frontend/package.json
+++ b/conversational-ai-platform/frontend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "frontend",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "serve dist",
+    "dev": "ts-node src/main.tsx",
+    "test": "echo 'no tests'"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "recharts": "^2.8.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.44",
+    "@types/react-dom": "^18.2.17",
+    "typescript": "^5.4.3",
+    "serve": "^14.2.0"
+  }
+}

--- a/conversational-ai-platform/frontend/src/App.tsx
+++ b/conversational-ai-platform/frontend/src/App.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { PieChart, Pie, Cell } from 'recharts';
+
+const data = [
+  { name: 'unemployment_info', value: 4 },
+  { name: 'pension_eligibility', value: 6 }
+];
+
+const COLORS = ['#0088FE', '#00C49F'];
+
+const App: React.FC = () => (
+  <div className="p-4">
+    <h1 className="text-xl font-bold mb-4">Dashboard</h1>
+    <PieChart width={400} height={300}>
+      <Pie data={data} dataKey="value" nameKey="name" label>
+        {data.map((entry, index) => (
+          <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+        ))}
+      </Pie>
+    </PieChart>
+  </div>
+);
+
+export default App;

--- a/conversational-ai-platform/frontend/src/main.tsx
+++ b/conversational-ai-platform/frontend/src/main.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import App from './App';
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/conversational-ai-platform/frontend/tsconfig.json
+++ b/conversational-ai-platform/frontend/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "ESNext",
+    "jsx": "react",
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- add project skeleton with backend and frontend packages
- include Dialogflow agent and Genesys flow samples
- provide Docker setup and Postman collection
- write simple README with usage instructions

## Testing
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876b6e35c20832db64bb2ce6a238ab8